### PR TITLE
Mostly fixed keyboard ghosting issue

### DIFF
--- a/drivers/misc/mediatek/aw9523/aw9523_key.c
+++ b/drivers/misc/mediatek/aw9523/aw9523_key.c
@@ -307,16 +307,18 @@ static void aw9523_key_eint_work(struct work_struct *work)
 {
 	struct aw9523_key_data *pdata;
 	KEY_STATE *keymap;
-	unsigned char i, j, cnt, update_now;
+	unsigned char i, j, idx;
 	unsigned char val;
+	bool update_now = false; // Used to detect ghosting
 	int keymap_len;
 	int x = 0;
 	int y = 0;
 	int t;
-	int keyIn;
-	// These data structures are large enough they won't overflow.
-	int keyCodes[P0_NUM_MAX*P1_NUM_MAX];
-	int keyValues[P0_NUM_MAX*P1_NUM_MAX];
+	// These data structures are large enough they can't overflow.
+	int press_count = 0;
+	int press_codes[P0_NUM_MAX*P1_NUM_MAX];
+	int release_count = 0;
+	int release_codes[P0_NUM_MAX*P1_NUM_MAX];
 	int discardKeyCheck;
 
 	AW9523_LOG("Handling Interrupt\n");
@@ -361,32 +363,40 @@ static void aw9523_key_eint_work(struct work_struct *work)
 	}
 	// AW9523_LOG("\n");
 
-	update_now = 0;  // FIXME can I use a boolean type with false?
+
+	/* This routine prevents ghosting.  As an example, if Control+L_Shift+N is pressed,
+	 * the keyboard detects both N & M at the same time due to the electronic circuit.
+	 * Rather than detect both keys, block both keys until either Control or L_Shift is
+	 * released, then detect the correct keypress. See youtu.be/L3ByBtM-w9I */
 	if (memcmp(keyst_old, keyst_new, P1_NUM_MAX)) {	// keyst changed
 		val = P0_KROW_MASK; // The distinct columns used
 		y = 0;
-		update_now = 1; // By default, do the update.
+		update_now = true; // Now by default, do the update since keyst changed.
 		for(i = 0; i < P1_NUM_MAX; i++) {
-			x = 0; // Will become the number of bits set in val (distinct columns)
+			if (keyst_new[i]==P0_KROW_MASK) {
+				// Most of the time no key is pressed, skip it.
+				continue;
+			}
+			x = 0; // Count the number of keys pressed (ie. clear bits)
 			for (j = 0; j < P0_NUM_MAX; j++) {
 				if (! (keyst_new[i] & (1 << j))) {	// press
 					x++; // Increase whenever this bit is clear.
-					if (! (val & (1 << j))) {
-						// Another row cleared this column.
-						// There's a conflict, block it.
-						update_now = 0;
-					}
+					// Boolean expression is false if a previous row
+					// also has this bit clear.  In this case, the
+					// keyboard is ghosting, and update_now is false.
+					update_now = update_now && (val & (1 << j));
 				}
 			}
-			// If more than one key in this row is pressed, check for conflicts.
+			// If more than one key in this row is pressed, remember which bits
+			// are clear so we can check for ghosting in other rows.
 			if (x>1) {
 				val &= keyst_new[i];
 			}
 		}
 	}
 
-	if (update_now) { // Key state change without blocking.
-		keyIn = 0;
+	// update_now is set when the key state changes and there's no ghosting right now.
+	if (update_now) {
 		for (t = 0; t < P1_NUM_MAX; t++) {
 			i = t;
 			// I'm not sure why these are swapped.  Is it still needed?
@@ -400,85 +410,85 @@ static void aw9523_key_eint_work(struct work_struct *work)
 			for (j = 0; j < P0_NUM_MAX; j++) {
 				if ((keyst_old[i] & (1 << j)) != (keyst_new[i] & (1 << j))) {	// j row & i col changed
 					// The keymap datastructure is organized this way.
-					cnt = i * P0_NUM_MAX + j;
+					idx = i * P0_NUM_MAX + j;
 					if (keyst_new[i] & (1 << j)) {	// release
-						keymap[cnt].key_val = 0;
+						keymap[idx].key_val = 0;
+						release_codes[release_count] = keymap[idx].key_code;
+						release_count++;
 					} else {	// press
-						keymap[cnt].key_val = 1;
+						keymap[idx].key_val = 1;
+						press_codes[press_count] = keymap[idx].key_code;
+						press_count++;
 					}
-					AW9523_LOG("Storing key in position %d code %d val %d\n",
-						   keyIn,
-						   keymap[cnt].key_code,
-						   keymap[cnt].key_val);
-					keyValues[keyIn] = keymap[cnt].key_val;
-					keyCodes[keyIn] = keymap[cnt].key_code;
-					keyIn++;
+					AW9523_LOG("Storing key code %d val %d\n",
+						   keymap[idx].key_code,
+						   keymap[idx].key_val);
 				}
 			}
 		}
-
-		for (t = 0; t < keyIn; t++) {
+		
+		/* Process key presses before releases because sometimes a release of one key will
+		 * unblock another key press, and we want to keep all modifier keys pressed. */
+		for (t = 0; t < press_count; t++) {
 			if (skipCycles == 0) {
 				if (discardKeyIdx > 0) {
 					AW9523_LOG("Clearing discarded keys\n");
 					discardKeyIdx = 0;
 				}
-				AW9523_LOG("Processing key in position %d code %d val %d\n",
-					   t, keyCodes[t], keyValues[t]);
+				AW9523_LOG("Processing key press in position %d code %d\n",
+					   t, press_codes[t]);
 				input_report_key(aw9523_key->input_dev,
-						 keyCodes[t],
-						 keyValues[t]);
+						 press_codes[t],
+						 1); // The one records a press
 				input_sync(aw9523_key->input_dev);
 				forceCycles = 100;
 			} else {
-				if (keyValues[t] == 1) {
-					// Key is pressed
-					if (discardKeyIdx < 99) {
-						AW9523_LOG("Putting key %d in discardKeys %d\n",
-							   keyCodes[t],
-							   discardKeyIdx);
-						discardKeys[discardKeyIdx] = keyCodes[t];
-						discardKeyIdx++;
-					}
-				} else {
-					// Key is released
-					for (discardKeyCheck = 0; discardKeyCheck < discardKeyIdx; discardKeyCheck++) {
-						if (discardKeys[discardKeyCheck] == keyCodes[t]) {
-							AW9523_LOG("Found key %d in discardKeys %d, discarding\n",
-								   keyCodes[t],
-								   discardKeyCheck);
-							discardKeyCheck = 999;
-						}
-					}
-					if (discardKeyCheck != 1000) {
-						AW9523_LOG("Releasing key in position %d code %d val %d (%d)\n",
-							   t, keyCodes[t],
-							   keyValues[t],
-							   discardKeyCheck);
-						input_report_key(aw9523_key->input_dev,
-								 keyCodes[t],
-								 keyValues[t]);
-						input_sync(aw9523_key->input_dev);
-					}
-					//switch(keyCodes[t]) {
-					//case 464:
-					//      fnPressed = keyValues[t];
-					//      break;
-					//case 29:
-					//      ctrlPressed = keyValues[t];
-					//      break;
-					//case 56:
-					//      altPressed = keyValues[t];
-					//      break;
-					//case 42:
-					//      shiftLeftPressed = keyValues[t];
-					//      break;
-					//case 54:
-					//      shiftRightPressed = keyValues[t];
-					//      break;
+				if (discardKeyIdx < 99) {
+					AW9523_LOG("Putting key press %d in discardKeys %d\n",
+						   press_codes[t],
+						   discardKeyIdx);
+					discardKeys[discardKeyIdx] = press_codes[t];
+					discardKeyIdx++;
 				}
 			}
 		}
+		// Now go through all the relaeses.
+		for (t = 0; t < release_count; t++) {
+			if (skipCycles == 0) {
+				if (discardKeyIdx > 0) {
+					AW9523_LOG("Clearing discarded keys\n");
+					discardKeyIdx = 0;
+				}
+				AW9523_LOG("Processing key release in position %d code %d\n",
+					   t, release_codes[t]);
+				input_report_key(aw9523_key->input_dev,
+						 release_codes[t],
+						 0); // The zero records a release
+				input_sync(aw9523_key->input_dev);
+				forceCycles = 100;
+			} else {
+				// Key is released
+				for (discardKeyCheck = 0; discardKeyCheck < discardKeyIdx; discardKeyCheck++) {
+					if (discardKeys[discardKeyCheck] == release_codes[t]) {
+						AW9523_LOG("Found key %d in discardKeys %d, discarding\n",
+							   release_codes[t],
+							   discardKeyCheck);
+						discardKeyCheck = 999;
+					}
+				}
+				if (discardKeyCheck != 1000) {
+					AW9523_LOG("Releasing key in position %d code %d (%d)\n",
+						   t, relase_key_code[t],
+						   discardKeyCheck);
+						input_report_key(aw9523_key->input_dev,
+								 release_codes[t],
+								 0); // Report the release.
+						input_sync(aw9523_key->input_dev);
+				}
+			}
+		}
+
+		// Store the current state so we can detect a change next time.
 		memcpy(keyst_old, keyst_new, P1_NUM_MAX);
 	}
 

--- a/drivers/misc/mediatek/aw9523/aw9523_key.c
+++ b/drivers/misc/mediatek/aw9523/aw9523_key.c
@@ -1,9 +1,9 @@
 /**************************************************************************
 *  aw9523_key.c
-* 
-*  Create Date : 
-* 
-*  Modify Date : 
+*
+*  Create Date :
+*
+*  Modify Date :
 *
 *  Create by   : AWINIC Technology CO., LTD
 *
@@ -42,9 +42,12 @@
 #define CONFIG_AW9523_FB
 #define AW9523_EARLAY_SUSPEND
 /**
-*add by wangyongsheng20171227 
+*add by wangyongsheng20171227
 *释 : 解决外扩按键在盒盖被压住时进不去休眠和偶尔出现按键不能相应
 *及让该设备在灭屏时就进入休眠不等系统调用suspend方法再进入
+*autmatic translation:
+*Release: Resolve the expansion button can not enter the sleep when the lid is pressed and occasionally the button does not correspond
+*And let the device enter hibernation when the screen is off. The system calls the suspend method and then enters.
 */
 
 #ifdef CONFIG_AW9523_FB
@@ -54,7 +57,7 @@
 
 #include "aw9523_key.h"
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////
-#define AW9523_I2C_NAME		"Integrated keyboard" 
+#define AW9523_I2C_NAME		"Integrated keyboard"
 
 #define P0_KROW_MASK 0xff
 #define P1_KCOL_MASK 0x7f
@@ -79,126 +82,130 @@
 
 //reg list
 #define P0_INPUT	0x00
-#define P1_INPUT 	0x01
-#define P0_OUTPUT 	0x02
-#define P1_OUTPUT 	0x03
+#define P1_INPUT	0x01
+#define P0_OUTPUT	0x02
+#define P1_OUTPUT	0x03
 #define P0_CONFIG	0x04
-#define P1_CONFIG 	0x05
+#define P1_CONFIG	0x05
 #define P0_INT		0x06
 #define P1_INT		0x07
 #define ID_REG		0x10
 #define CTL_REG		0x11
 #define P0_LED_MODE	0x12
 #define P1_LED_MODE	0x13
-#define P1_0_DIM0   0x20
-#define P1_1_DIM0   0x21
-#define P1_2_DIM0   0x22
-#define P1_3_DIM0   0x23
-#define P0_0_DIM0   0x24
-#define P0_1_DIM0   0x25
-#define P0_2_DIM0   0x26
-#define P0_3_DIM0   0x27
-#define P0_4_DIM0   0x28
-#define P0_5_DIM0   0x29
-#define P0_6_DIM0   0x2A
-#define P0_7_DIM0   0x2B
-#define P1_4_DIM0   0x2C
-#define P1_5_DIM0   0x2D
-#define P1_6_DIM0   0x2E
-#define P1_7_DIM0   0x2F
+#define P1_0_DIM0	0x20
+#define P1_1_DIM0	0x21
+#define P1_2_DIM0	0x22
+#define P1_3_DIM0	0x23
+#define P0_0_DIM0	0x24
+#define P0_1_DIM0	0x25
+#define P0_2_DIM0	0x26
+#define P0_3_DIM0	0x27
+#define P0_4_DIM0	0x28
+#define P0_5_DIM0	0x29
+#define P0_6_DIM0	0x2A
+#define P0_7_DIM0	0x2B
+#define P1_4_DIM0	0x2C
+#define P1_5_DIM0	0x2D
+#define P1_6_DIM0	0x2E
+#define P1_7_DIM0	0x2F
 #define SW_RSTN		0x7F
 
 #define HRTIMER_FRAME	100//20
 
 KEY_STATE key_map[]={
-//	name		code					val		row			col
-	{"1",	KEY_1,					0,	KROW_P0_0,	KROW_P1_0},  //
-	{"U"	,	KEY_U,					0,	KROW_P0_1,	KROW_P1_0},  //
-	{"S"	,	KEY_S,				0,	KROW_P0_2,	KROW_P1_0},  //
-	{"Z"	,	KEY_Z,					0,	KROW_P0_3,	KROW_P1_0}, //
-	{","	,	KEY_COMMA,					0,	KROW_P0_4,	KROW_P1_0}, //
-	{"~"	,	KEY_APOSTROPHE,					0,	KROW_P0_5,	KROW_P1_0}, //
-	{"8"	,	KEY_8,					0,	KROW_P0_6,	KROW_P1_0},  //
-	{"J"	,	KEY_J,					0,	KROW_P0_7,	KROW_P1_0},  //
+//	name		code				val	row		col
+	{"1"	,	KEY_1,				0,	KROW_P0_0,	KROW_P1_0},
+	{"U"	,	KEY_U,				0,	KROW_P0_1,	KROW_P1_0},
+	{"S"	,	KEY_S,				0,	KROW_P0_2,	KROW_P1_0},
+	{"Z"	,	KEY_Z,				0,	KROW_P0_3,	KROW_P1_0},
+	{","	,	KEY_COMMA,			0,	KROW_P0_4,	KROW_P1_0},
+	{"~"	,	KEY_APOSTROPHE,			0,	KROW_P0_5,	KROW_P1_0},
+	{"8"	,	KEY_8,				0,	KROW_P0_6,	KROW_P1_0},
+	{"J"	,	KEY_J,				0,	KROW_P0_7,	KROW_P1_0},
 
-	{"2",	KEY_2,					0,	KROW_P0_0,	KROW_P1_1},  //
-	{"W"	,	KEY_W,					0,	KROW_P0_1,	KROW_P1_1},  //
-	{"D"	,	KEY_D,				0,	KROW_P0_2,	KROW_P1_1},  //
-	{"C"	,	KEY_C,					0,	KROW_P0_3,	KROW_P1_1}, //
-	{"ALT-L"	,	KEY_LEFTALT,					0,	KROW_P0_4,	KROW_P1_1}, //
-	{"LEFT"	,	KEY_LEFT,					0,	KROW_P0_5,	KROW_P1_1}, //
-	{"9"	,	KEY_9,					0,	KROW_P0_6,	KROW_P1_1},  //
-	{"K"	,	KEY_K,					0,	KROW_P0_7,	KROW_P1_1},  //
+	{"2"	,	KEY_2,				0,	KROW_P0_0,	KROW_P1_1},
+	{"W"	,	KEY_W,				0,	KROW_P0_1,	KROW_P1_1},
+	{"D"	,	KEY_D,				0,	KROW_P0_2,	KROW_P1_1},
+	{"C"	,	KEY_C,				0,	KROW_P0_3,	KROW_P1_1},
+	{"ALT-L",	KEY_LEFTALT,			0,	KROW_P0_4,	KROW_P1_1},
+	{"LEFT"	,	KEY_LEFT,			0,	KROW_P0_5,	KROW_P1_1},
+	{"9"	,	KEY_9,				0,	KROW_P0_6,	KROW_P1_1},
+	{"K"	,	KEY_K,				0,	KROW_P0_7,	KROW_P1_1},
 
-	{"3",	KEY_3,					0,	KROW_P0_0,	KROW_P1_2},  //
-	{"Y"	,	KEY_Y,					0,	KROW_P0_1,	KROW_P1_2},  //
-	{"TAB"	,	KEY_TAB,				0,	KROW_P0_2,	KROW_P1_2},  //
-	{"N"	,	KEY_N,					0,	KROW_P0_3,	KROW_P1_2}, //
-	{"M"	,	KEY_M,					0,	KROW_P0_4,	KROW_P1_2}, //
-	{"PGDN"	,	KEY_DOWN/*KEY_PAGEDOWN*/,					0,	KROW_P0_5,	KROW_P1_2}, //
-	{"DEL"	,	KEY_BACKSPACE,					0,	KROW_P0_6,	KROW_P1_2},  //
-	{"I"	,	KEY_I,					0,	KROW_P0_7,	KROW_P1_2},  //
+	{"3"	,	KEY_3,				0,	KROW_P0_0,	KROW_P1_2},
+	{"Y"	,	KEY_Y,				0,	KROW_P0_1,	KROW_P1_2},
+	{"TAB"	,	KEY_TAB,			0,	KROW_P0_2,	KROW_P1_2},
+	{"N"	,	KEY_N,				0,	KROW_P0_3,	KROW_P1_2},
+	{"M"	,	KEY_M,				0,	KROW_P0_4,	KROW_P1_2},
+	{"PGDN"	,	KEY_DOWN/*KEY_PAGEDOWN*/,	0,	KROW_P0_5,	KROW_P1_2},
+	{"DEL"	,	KEY_BACKSPACE,			0,	KROW_P0_6,	KROW_P1_2},
+	{"I"	,	KEY_I,				0,	KROW_P0_7,	KROW_P1_2},
 
-	{"4",	KEY_4,					0,	KROW_P0_0,	KROW_P1_3},  //
-	{"T"	,	KEY_T,					0,	KROW_P0_1,	KROW_P1_3},  //
-	{"F"	,	KEY_F,				0,	KROW_P0_2,	KROW_P1_3},  //
-	{"X"	,	KEY_X,					0,	KROW_P0_3,	KROW_P1_3}, //
-	{"META-L"	,	KEY_LEFTMETA,					0,	KROW_P0_4,	KROW_P1_3}, //
-	{"SHIFT-R"	,	KEY_RIGHTSHIFT,					0,	KROW_P0_5,	KROW_P1_3}, //
-	{"P"	,	KEY_P,					0,	KROW_P0_6,	KROW_P1_3},  //
-	{"NULL"	,	KEY_UNKNOWN,					0,	KROW_P0_7,	KROW_P1_3},  //
+	{"4"	,	KEY_4,				0,	KROW_P0_0,	KROW_P1_3},
+	{"T"	,	KEY_T,				0,	KROW_P0_1,	KROW_P1_3},
+	{"F"	,	KEY_F,				0,	KROW_P0_2,	KROW_P1_3},
+	{"X"	,	KEY_X,				0,	KROW_P0_3,	KROW_P1_3},
+	{"META-L",	KEY_LEFTMETA,			0,	KROW_P0_4,	KROW_P1_3},
+	{"SHIFT-R",	KEY_RIGHTSHIFT,			0,	KROW_P0_5,	KROW_P1_3},
+	{"P"	,	KEY_P,				0,	KROW_P0_6,	KROW_P1_3},
+	{"NULL"	,	KEY_UNKNOWN,			0,	KROW_P0_7,	KROW_P1_3},
 
-	{"5"	,	KEY_5,					0,	KROW_P0_0,	KROW_P1_4},  //
-	{"E"	,	KEY_E,					0,	KROW_P0_1,	KROW_P1_4},  //
-	{"G"	,	KEY_G,					0,	KROW_P0_2,	KROW_P1_4},  //
-	{"V"	,	KEY_V,					0,	KROW_P0_3,	KROW_P1_4},  //
-	{"SPACE",	KEY_SPACE,					0,	KROW_P0_4,	KROW_P1_4},  //
-	{"PGUP"	,	KEY_UP/*KEY_PAGEUP*/,					0,	KROW_P0_5,	KROW_P1_4},  //
-	{"O"	,	KEY_O,					0,	KROW_P0_6,	KROW_P1_4},  //
-	{"NULL"	,	KEY_UNKNOWN,					0,	KROW_P0_7,	KROW_P1_4},  //
+	{"5"	,	KEY_5,				0,	KROW_P0_0,	KROW_P1_4},
+	{"E"	,	KEY_E,				0,	KROW_P0_1,	KROW_P1_4},
+	{"G"	,	KEY_G,				0,	KROW_P0_2,	KROW_P1_4},
+	{"V"	,	KEY_V,				0,	KROW_P0_3,	KROW_P1_4},
+	{"SPACE",	KEY_SPACE,			0,	KROW_P0_4,	KROW_P1_4},
+	{"PGUP"	,	KEY_UP/*KEY_PAGEUP*/,		0,	KROW_P0_5,	KROW_P1_4},
+	{"O"	,	KEY_O,				0,	KROW_P0_6,	KROW_P1_4},
+	{"NULL"	,	KEY_UNKNOWN,			0,	KROW_P0_7,	KROW_P1_4},
 
-	{"6"	,	KEY_6,					0,	KROW_P0_0,	KROW_P1_5},  //
-	{"Q"	,	KEY_Q,					0,	KROW_P0_1,	KROW_P1_5},   //
-	{"A",	KEY_A,					0,	KROW_P0_2,	KROW_P1_5},  //
-	{"B"	,	KEY_B,					0,	KROW_P0_3,	KROW_P1_5},   //
-	{"?"	,	KEY_DOT,					0,	KROW_P0_4,	KROW_P1_5},  //
-	{"RIGHT"	,	KEY_RIGHT,					0,	KROW_P0_5,	KROW_P1_5},  //
-	{"ENTER"	,	KEY_ENTER,					0,	KROW_P0_6,	KROW_P1_5},  //
-	{"NULL"	,	KEY_UNKNOWN,					0,	KROW_P0_7,	KROW_P1_5},  //
+	{"6"	,	KEY_6,				0,	KROW_P0_0,	KROW_P1_5},
+	{"Q"	,	KEY_Q,				0,	KROW_P0_1,	KROW_P1_5},
+	{"A"	,	KEY_A,				0,	KROW_P0_2,	KROW_P1_5},
+	{"B"	,	KEY_B,				0,	KROW_P0_3,	KROW_P1_5},
+	{"?"	,	KEY_DOT,			0,	KROW_P0_4,	KROW_P1_5},
+	{"RIGHT",	KEY_RIGHT,			0,	KROW_P0_5,	KROW_P1_5},
+	{"ENTER",	KEY_ENTER,			0,	KROW_P0_6,	KROW_P1_5},
+	{"NULL"	,	KEY_UNKNOWN,			0,	KROW_P0_7,	KROW_P1_5},
 
-	{"7"	,	KEY_7,					0,	KROW_P0_0,	KROW_P1_6},  //
-	{"R"	,	KEY_R,					0,	KROW_P0_1,	KROW_P1_6},   //
-	{"H",	KEY_H,					0,	KROW_P0_2,	KROW_P1_6},  //
-	{"SHIFT-L"	,	KEY_LEFTSHIFT,					0,	KROW_P0_3,	KROW_P1_6},   //
-	{"CTRL"	,	KEY_LEFTCTRL,					0,	KROW_P0_4,	KROW_P1_6},  //
-	{"L"	,	KEY_L,					0,	KROW_P0_5,	KROW_P1_6},  //
-	{"0"	,	KEY_0,					0,	KROW_P0_6,	KROW_P1_6},  //
-	{"NULL"	,	KEY_UNKNOWN,					0,	KROW_P0_7,	KROW_P1_6},  //
+	{"7"	,	KEY_7,				0,	KROW_P0_0,	KROW_P1_6},
+	{"R"	,	KEY_R,				0,	KROW_P0_1,	KROW_P1_6},
+	{"H"	,	KEY_H,				0,	KROW_P0_2,	KROW_P1_6},
+	{"SHIFT-L",	KEY_LEFTSHIFT,			0,	KROW_P0_3,	KROW_P1_6},
+	{"CTRL"	,	KEY_LEFTCTRL,			0,	KROW_P0_4,	KROW_P1_6},
+	{"L"	,	KEY_L,				0,	KROW_P0_5,	KROW_P1_6},
+	{"0"	,	KEY_0,				0,	KROW_P0_6,	KROW_P1_6},
+	{"NULL"	,	KEY_UNKNOWN,			0,	KROW_P0_7,	KROW_P1_6},
 };
 
-#define P0_NUM_MAX		8
-#define P1_NUM_MAX		7
-#define KEYST_MAX		2
-#define KEYST_OLD		0
-#define KEYST_NEW		1
+#define P0_NUM_MAX	8
+#define P1_NUM_MAX	7
+#define KEYST_MAX	2
+#define KEYST_OLD	0
+#define KEYST_NEW	1
 static unsigned char keyst_old[P1_NUM_MAX];
 static unsigned char keyst_new[P1_NUM_MAX];
 
 static unsigned char keyst_def[KEYST_MAX][P1_NUM_MAX];
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////
-static unsigned char i2c_write_reg(unsigned char addr, unsigned char reg_data);
+static unsigned char i2c_write_reg(unsigned char addr,
+				   unsigned char reg_data);
 static unsigned char i2c_read_reg(unsigned char addr);
 
-static ssize_t aw9523_get_reg(struct device* cd,struct device_attribute *attr, char* buf);
-static ssize_t aw9523_set_reg(struct device* cd, struct device_attribute *attr,const char* buf, size_t len);
+static ssize_t aw9523_get_reg(struct device *cd,
+			      struct device_attribute *attr, char *buf);
+static ssize_t aw9523_set_reg(struct device *cd,
+			      struct device_attribute *attr,
+			      const char *buf, size_t len);
 
-static DEVICE_ATTR(reg, 0660, aw9523_get_reg,  aw9523_set_reg);
+static DEVICE_ATTR(reg, 0660, aw9523_get_reg, aw9523_set_reg);
 
 struct aw9523_key_data {
-	struct device       *dev;
-	struct input_dev	*input_dev;
-	struct work_struct 	eint_work;
+	struct device *dev;
+	struct input_dev *input_dev;
+	struct work_struct eint_work;
 	struct device_node *irq_node;
 	struct hrtimer key_timer;
 	int irq;
@@ -207,10 +214,10 @@ struct aw9523_key_data {
 	KEY_STATE *keymap;
 	int keymap_len;
 #ifdef CONFIG_AW9523_FB
-		struct notifier_block	fb_notif;
+	struct notifier_block fb_notif;
 #endif
-		
-		bool is_screen_on;
+
+	bool is_screen_on;
 };
 
 struct aw9523_pinctrl {
@@ -232,14 +239,14 @@ struct i2c_client *aw9523_i2c_client;
 
 #ifdef CONFIG_AW9523_FB
 static int aw9523_fb_notifier_callback(struct notifier_block *self,
-                     unsigned long event, void *data);
+				       unsigned long event, void *data);
 #endif
 #ifdef AW9523_EARLAY_SUSPEND
 static void aw9523_i2c_early_suspend(struct i2c_client *client);
 static void aw9523_i2c_early_resume(struct i2c_client *client);
 #endif
 #define MAX_KEYS_TOGETHER 4
-int skipCycles=0;
+int skipCycles = 0;
 int calledByHRTimer = 0;
 int forceCycles = 0;
 
@@ -259,14 +266,14 @@ static int aw9523_pinctrl_init(struct platform_device *pdev)
 {
 	int ret = 0;
 	aw9523_pin = devm_pinctrl_get(&pdev->dev);
-    AW9523_LOG("%s : pinctrl init 00000000\n", __func__);
+	AW9523_LOG("%s : pinctrl init 00000000\n", __func__);
 	if (IS_ERR(aw9523_pin)) {
 		dev_err(&pdev->dev, "Cannot find aw9523 pinctrl!");
 		ret = PTR_ERR(aw9523_pin);
 		printk("%s devm_pinctrl_get fail!\n", __func__);
 	}
-	
-    AW9523_LOG("%s : pinctrl init 11111111\n", __func__);
+
+	AW9523_LOG("%s : pinctrl init 11111111\n", __func__);
 	shdn_high = pinctrl_lookup_state(aw9523_pin, "aw9523_shdn_high");
 	if (IS_ERR(shdn_high)) {
 		ret = PTR_ERR(shdn_high);
@@ -297,39 +304,39 @@ static void aw9523_hw_reset(void)
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////
 static void aw9523_key_eint_work(struct work_struct *work)
 {
-	struct aw9523_key_data *pdata;  
+	struct aw9523_key_data *pdata;
 	KEY_STATE *keymap;
-	unsigned char i,j,cnt;
+	unsigned char i, j, cnt;
 	unsigned char val;
 	int keymap_len;
-	int x=0;
-	int y=0;
+	int x = 0;
+	int y = 0;
 	int t;
 	int keyIn;
 	int keyCodes[100];
-    int keyValues[100];
-    int discardKeyCheck;
+	int keyValues[100];
+	int discardKeyCheck;
 
 	AW9523_LOG("Handling Interrupt\n");
 
-	if(!aw9523_key->is_screen_on) {
-        AW9523_LOG("Screen is off, reenable IRQ\n");
+	if (!aw9523_key->is_screen_on) {
+		AW9523_LOG("Screen is off, reenable IRQ\n");
 
-        val = i2c_read_reg(P1_CONFIG);
-        i2c_write_reg(P1_CONFIG, val & (~P1_KCOL_MASK));			//set p1 port output mode
+		val = i2c_read_reg(P1_CONFIG);
+		i2c_write_reg(P1_CONFIG, val & (~P1_KCOL_MASK));	//set p1 port output mode
 
-        val = i2c_read_reg(P1_OUTPUT);
-        i2c_write_reg(P1_OUTPUT, val & (~P1_KCOL_MASK));		//p1 port output 0
+		val = i2c_read_reg(P1_OUTPUT);
+		i2c_write_reg(P1_OUTPUT, val & (~P1_KCOL_MASK));	//p1 port output 0
 
-        val = i2c_read_reg(P0_INPUT);						//clear p0 input irq
+		val = i2c_read_reg(P0_INPUT);	//clear p0 input irq
 
-        val = i2c_read_reg(P0_INT);
-        //i2c_write_reg(P0_INT, val & (~P0_KROW_MASK));		//enable p0 port irq
-        i2c_write_reg(P0_INT, 0x00);		//enable p0 port irq
+		val = i2c_read_reg(P0_INT);
+		//i2c_write_reg(P0_INT, val & (~P0_KROW_MASK));         //enable p0 port irq
+		i2c_write_reg(P0_INT, 0x00);	//enable p0 port irq
 
-        enable_irq(aw9523_key->irq);
-        return;
-    }
+		enable_irq(aw9523_key->irq);
+		return;
+	}
 
 
 	pdata = aw9523_key;
@@ -337,83 +344,81 @@ static void aw9523_key_eint_work(struct work_struct *work)
 	keymap = pdata->keymap;
 	keymap_len = pdata->keymap_len;
 
-	for (i=0; i<P1_NUM_MAX; i++) {    
-		if (P1_KCOL_MASK & (1<<i)) {
+	for (i = 0; i < P1_NUM_MAX; i++) {
+		if (P1_KCOL_MASK & (1 << i)) {
 			val = i2c_read_reg(P1_CONFIG);
-			i2c_write_reg(P1_CONFIG, (P1_KCOL_MASK | val) & (~(1<<i)));					//set p1_x port output mode
+			i2c_write_reg(P1_CONFIG, (P1_KCOL_MASK | val) & (~(1 << i)));	//set p1_x port output mode
 			val = i2c_read_reg(P1_OUTPUT);
-			i2c_write_reg(P1_OUTPUT, (P1_KCOL_MASK | val) & (~(1<<i)));
-			
-			val = i2c_read_reg(P0_INPUT);						// read p0 port status
-			if(aw9523_key->is_screen_on)
-			keyst_new[i] = (val & P0_KROW_MASK);
+			i2c_write_reg(P1_OUTPUT, (P1_KCOL_MASK | val) & (~(1 << i)));
+
+			val = i2c_read_reg(P0_INPUT);	// read p0 port status
+			if (aw9523_key->is_screen_on)
+				keyst_new[i] = (val & P0_KROW_MASK);
 			//printk("0x%02x, ", keyst_new[i]);                //i=p1 keyst[i]=p0
 		}
 	}
 	// AW9523_LOG("\n");
 
 	if (memcmp(keyst_old, keyst_new, P1_NUM_MAX)) {	// keyst changed
-	    keyIn = 0;
-		for (t=0; t<P1_NUM_MAX; t++) {
+		keyIn = 0;
+		for (t = 0; t < P1_NUM_MAX; t++) {
 			i = t;
-			if (t== 3) 
+			if (t == 3)
 				i = 6;
-			if (t == 6) 
+			if (t == 6)
 				i = 3;
-			if (keyst_old[i] != keyst_new[i]) 
-			{		// keyst of i col changed
-				for (j=0; j<P0_NUM_MAX; j++) 
-				{
-					y=0;
-					if (P0_KROW_MASK & (1<<j)) 
-					{								// j row gpio used
-						if ((keyst_old[i] & (1<<j)) != (keyst_new[i] & (1<<j))) {				// j row & i col changed
-							for (cnt=0; cnt<keymap_len; cnt++) {		// find row&col in the keymap
+			if (keyst_old[i] != keyst_new[i]) {	// keyst of i col changed
+				for (j = 0; j < P0_NUM_MAX; j++) {
+					y = 0;
+					if (P0_KROW_MASK & (1 << j)) {	// j row gpio used
+						if ((keyst_old[i] & (1 << j)) != (keyst_new[i] & (1 << j))) {	// j row & i col changed
+							for (cnt = 0; cnt < keymap_len; cnt++) {	// find row&col in the keymap
 								if ((keymap[cnt].row == j) && (keymap[cnt].col == i)) {
 									break;
 								}
 							}
-							if (keyst_new[i] & (1<<j)) {				// release
+							if (keyst_new[i] & (1 << j)) {	// release
 								keymap[cnt].key_val = 0;
-							} else {										// press
+							} else {	// press
 								keymap[cnt].key_val = 1;
 								x++;
 								y++;
 							}
 							if (keyIn < 100) {
-							    AW9523_LOG("Storing key in position %d code %d val %d\n", keyIn, keymap[cnt].key_code, keymap[cnt].key_val);
-                            	keyValues[keyIn] = keymap[cnt].key_val;
-                            	keyCodes[keyIn] = keymap[cnt].key_code;
-                            	keyIn++;
-                            }
-                            else {
-                                AW9523_LOG("Too many keys - giving up");
-                            }
-                            // if (keyIn > MAX_KEYS_TOGETHER) {
-                            if (x >= 4 || y >= 3) {
-                                AW9523_LOG("Too many keys\n");
-                                skipCycles = 50;
-                                forceCycles = 0;
-                            }
-
+								AW9523_LOG("Storing key in position %d code %d val %d\n",
+									   keyIn,
+									   keymap[cnt].key_code,
+									   keymap[cnt].key_val);
+								keyValues[keyIn] = keymap[cnt].key_val;
+								keyCodes[keyIn] = keymap[cnt].key_code;
+								keyIn++;
+							} else {
+								AW9523_LOG("Too many keys - giving up");
+							}
+							// if (keyIn > MAX_KEYS_TOGETHER) {
+							if (x >= 4 || y >= 3) {
+								AW9523_LOG("Too many keys\n");
+								skipCycles = 50;
+								forceCycles = 0;
+							}
 							//if (x < 4 && y < 3) {
-								//if (keyIn < 10) {
-								    //AW9523_LOG("Cycle %d - Storing key in position %d\n code %d val %d", keyCurrentCycle, keyIn, keymap[cnt].key_code, keymap[cnt].key_val);
-									//keyValues[keyIn] = keymap[cnt].key_val;
-									//keyCodes[keyIn] = keymap[cnt].key_code;
-									//keyIn++;
-								//}
-								//input_report_key(aw9523_key->input_dev, keymap[cnt].key_code, keymap[cnt].key_val);
-								//input_sync(aw9523_key->input_dev);
-								//AW9523_LOG("%s: key_report: p0-row=%d, p1-col=%d, key_code=%d, key_val=%d\n",
-								//	__func__, j, i, keymap[cnt].key_code, keymap[cnt].key_val);
-								//if (keymap[cnt].key_code == KEY_Z && keymap[cnt].key_val == 0) {
-                                //    if (keySkipCycle < 6)
-                                //        keySkipCycle++;
-                                //    else
-                                //        keySkipCycle = 1;
-                                //    AW9523_LOG("Cycle %d - Setting skip cycle to %d\n", keyCurrentCycle, keySkipCycle);
-                                //}
+							//if (keyIn < 10) {
+							//AW9523_LOG("Cycle %d - Storing key in position %d\n code %d val %d", keyCurrentCycle, keyIn, keymap[cnt].key_code, keymap[cnt].key_val);
+							//keyValues[keyIn] = keymap[cnt].key_val;
+							//keyCodes[keyIn] = keymap[cnt].key_code;
+							//keyIn++;
+							//}
+							//input_report_key(aw9523_key->input_dev, keymap[cnt].key_code, keymap[cnt].key_val);
+							//input_sync(aw9523_key->input_dev);
+							//AW9523_LOG("%s: key_report: p0-row=%d, p1-col=%d, key_code=%d, key_val=%d\n",
+							//      __func__, j, i, keymap[cnt].key_code, keymap[cnt].key_val);
+							//if (keymap[cnt].key_code == KEY_Z && keymap[cnt].key_val == 0) {
+							//      if (keySkipCycle < 6)
+							//              keySkipCycle++;
+							//      else
+							//              keySkipCycle = 1;
+							//      AW9523_LOG("Cycle %d - Setting skip cycle to %d\n", keyCurrentCycle, keySkipCycle);
+							//}
 							//}
 						}
 					}
@@ -422,128 +427,141 @@ static void aw9523_key_eint_work(struct work_struct *work)
 		}
 
 		//if ((keyIn <= MAX_KEYS_TOGETHER)) {
-            for (t=0; t < keyIn; t++) {
-                if (skipCycles == 0) {
-                    if (discardKeyIdx > 0) {
-                        AW9523_LOG("Clearing discarded keys\n");
-                        discardKeyIdx = 0;
-                    }
-                    AW9523_LOG("Processing key in position %d code %d val %d\n", t, keyCodes[t], keyValues[t]);
-                    input_report_key(aw9523_key->input_dev, keyCodes[t], keyValues[t]);
-                    input_sync(aw9523_key->input_dev);
-                    forceCycles = 100;
-                }
-                else {
-                    if (keyValues[t] == 1) {
-                        // Key is pressed
-                        if (discardKeyIdx < 99) {
-                            AW9523_LOG("Putting key %d in discardKeys %d\n", keyCodes[t], discardKeyIdx);
-                            discardKeys[discardKeyIdx] = keyCodes[t];
-                            discardKeyIdx++;
-                        }
-                    }
-                    else {
-                        // Key is released
-                        for (discardKeyCheck=0;discardKeyCheck<discardKeyIdx;discardKeyCheck++) {
-                            if (discardKeys[discardKeyCheck] == keyCodes[t]) {
-                                AW9523_LOG("Found key %d in discardKeys %d, discarding\n", keyCodes[t], discardKeyCheck);
-                                discardKeyCheck = 999;
-                            }
-                        }
-                        if (discardKeyCheck != 1000) {
-                            AW9523_LOG("Releasing key in position %d code %d val %d (%d)\n", t, keyCodes[t], keyValues[t], discardKeyCheck);
-                            input_report_key(aw9523_key->input_dev, keyCodes[t], keyValues[t]);
-                            input_sync(aw9523_key->input_dev);
-                        }
-
-                    //switch(keyCodes[t]) {
-                    //case 464:
-                    //    fnPressed = keyValues[t];
-                    //    break;
-                    //case 29:
-                    //    ctrlPressed = keyValues[t];
-                    //    break;
-                    //case 56:
-                    //    altPressed = keyValues[t];
-                    //    break;
-                    //case 42:
-                    //    shiftLeftPressed = keyValues[t];
-                    //    break;
-                    //case 54:
-                    //    shiftRightPressed = keyValues[t];
-                    //    break;
-                    }
-                }
-            }
+		for (t = 0; t < keyIn; t++) {
+			if (skipCycles == 0) {
+				if (discardKeyIdx > 0) {
+					AW9523_LOG("Clearing discarded keys\n");
+					discardKeyIdx = 0;
+				}
+				AW9523_LOG("Processing key in position %d code %d val %d\n",
+					   t, keyCodes[t], keyValues[t]);
+				input_report_key(aw9523_key->input_dev,
+						 keyCodes[t],
+						 keyValues[t]);
+				input_sync(aw9523_key->input_dev);
+				forceCycles = 100;
+			} else {
+				if (keyValues[t] == 1) {
+					// Key is pressed
+					if (discardKeyIdx < 99) {
+						AW9523_LOG("Putting key %d in discardKeys %d\n",
+							   keyCodes[t],
+							   discardKeyIdx);
+						discardKeys[discardKeyIdx] = keyCodes[t];
+						discardKeyIdx++;
+					}
+				} else {
+					// Key is released
+					for (discardKeyCheck = 0; discardKeyCheck < discardKeyIdx; discardKeyCheck++) {
+						if (discardKeys[discardKeyCheck] == keyCodes[t]) {
+							AW9523_LOG("Found key %d in discardKeys %d, discarding\n",
+								   keyCodes[t],
+								   discardKeyCheck);
+							discardKeyCheck = 999;
+						}
+					}
+					if (discardKeyCheck != 1000) {
+						AW9523_LOG("Releasing key in position %d code %d val %d (%d)\n",
+							   t, keyCodes[t],
+							   keyValues[t],
+							   discardKeyCheck);
+						input_report_key(aw9523_key->input_dev,
+								 keyCodes[t],
+								 keyValues[t]);
+						input_sync(aw9523_key->input_dev);
+					}
+					//switch(keyCodes[t]) {
+					//case 464:
+					//      fnPressed = keyValues[t];
+					//      break;
+					//case 29:
+					//      ctrlPressed = keyValues[t];
+					//      break;
+					//case 56:
+					//      altPressed = keyValues[t];
+					//      break;
+					//case 42:
+					//      shiftLeftPressed = keyValues[t];
+					//      break;
+					//case 54:
+					//      shiftRightPressed = keyValues[t];
+					//      break;
+				}
+			}
+		}
 		//}
 		memcpy(keyst_old, keyst_new, P1_NUM_MAX);
 	}
 
-    if (skipCycles == 0 && forceCycles > 0) {
-        AW9523_LOG("Force Scheduling matrix rescan %d\n", forceCycles);
-        calledByHRTimer = 1;
-        hrtimer_start(&pdata->key_timer, ktime_set(0,(1000/HRTIMER_FRAME)*1000000), HRTIMER_MODE_REL);
-        forceCycles--;
-        return;
-    }
+	if (skipCycles == 0 && forceCycles > 0) {
+		AW9523_LOG("Force Scheduling matrix rescan %d\n",
+			   forceCycles);
+		calledByHRTimer = 1;
+		hrtimer_start(&pdata->key_timer,
+			      ktime_set(0, (1000 / HRTIMER_FRAME) * 1000000),
+			      HRTIMER_MODE_REL);
+		forceCycles--;
+		return;
+	}
 
-    if (skipCycles > 0) {
-        AW9523_LOG("Skipping cycle %d\n", skipCycles);
-        skipCycles--;
-    }
-
+	if (skipCycles > 0) {
+		AW9523_LOG("Skipping cycle %d\n", skipCycles);
+		skipCycles--;
+	}
 	//keyCurrentCycle++;
 	//if (keyCurrentCycle >= keySkipCycle) {
-	//	if (keyIn <= keyMaxKeys) {
-	//		for (t=0;t<keyIn;t++) {
-    //            	//input_report_key(aw9523_key->input_dev, keyCodes[t], keyValues[t]);
-    //				//input_sync(aw9523_key->input_dev);
-    //            	AW9523_LOG("Cycle %d - Releasing key %s: key_code=%d, key_val=%d\n", keyCurrentCycle,
-    //            	    	__func__, keyCodes[t], keyValues[t]);
-	//		}
-	//	}
-	//	else
-	//		AW9523_LOG("Cycle %d - Too many keys - flushing keys\n", keyCurrentCycle);
-	//	keyIn = 0;
-	//	keyCurrentCycle = 0;
+	//      if (keyIn <= keyMaxKeys) {
+	//              for (t=0;t<keyIn;t++) {
+	//                              //input_report_key(aw9523_key->input_dev, keyCodes[t], keyValues[t]);
+	//                              //input_sync(aw9523_key->input_dev);
+	//                              AW9523_LOG("Cycle %d - Releasing key %s: key_code=%d, key_val=%d\n", keyCurrentCycle,
+	//                                              __func__, keyCodes[t], keyValues[t]);
+	//              }
+	//      }
+	//      else
+	//              AW9523_LOG("Cycle %d - Too many keys - flushing keys\n", keyCurrentCycle);
+	//      keyIn = 0;
+	//      keyCurrentCycle = 0;
 	//}
 
 
-	if(((!(memcmp(&keyst_new[0], &keyst_def[KEYST_NEW][0], P1_NUM_MAX))) && (skipCycles == 0))||(!aw9523_key->is_screen_on)) {			// all key release   
+	if (((!(memcmp(&keyst_new[0], &keyst_def[KEYST_NEW][0], P1_NUM_MAX))) && (skipCycles == 0)) || (!aw9523_key->is_screen_on)) {	// all key release
 		//keyIn = 0;
 		//keyCurrentCycle = 0;
 		if (aw9523_key->is_screen_on) {
-		    AW9523_LOG("Clearing discarded keys\n");
-            discardKeyIdx = 0;
-        }
+			AW9523_LOG("Clearing discarded keys\n");
+			discardKeyIdx = 0;
+		}
 
 
 		if (calledByHRTimer == 0)
-		    AW9523_LOG("****** Bad, I lost a key here!\n");
+			AW9523_LOG("****** Bad, I lost a key here!\n");
 		AW9523_LOG("IRQ Re-enabled\n");
 
-		val = i2c_read_reg(P1_CONFIG);	
-		i2c_write_reg(P1_CONFIG, val & (~P1_KCOL_MASK));			//set p1 port output mode
-		
+		val = i2c_read_reg(P1_CONFIG);
+		i2c_write_reg(P1_CONFIG, val & (~P1_KCOL_MASK));	//set p1 port output mode
+
 		val = i2c_read_reg(P1_OUTPUT);
-		i2c_write_reg(P1_OUTPUT, val & (~P1_KCOL_MASK));		//p1 port output 0
-					
-		val = i2c_read_reg(P0_INPUT);						//clear p0 input irq
-		
+		i2c_write_reg(P1_OUTPUT, val & (~P1_KCOL_MASK));	//p1 port output 0
+
+		val = i2c_read_reg(P0_INPUT);	//clear p0 input irq
+
 		val = i2c_read_reg(P0_INT);
-		//i2c_write_reg(P0_INT, val & (~P0_KROW_MASK));		//enable p0 port irq
-		i2c_write_reg(P0_INT, 0x00);		//enable p0 port irq
-		
+		//i2c_write_reg(P0_INT, val & (~P0_KROW_MASK));         //enable p0 port irq
+		i2c_write_reg(P0_INT, 0x00);	//enable p0 port irq
+
 		enable_irq(aw9523_key->irq);
 		AW9523_LOG("Done\n");
 		return;
 	}
 
-    AW9523_LOG("Scheduling matrix rescan\n");
-    calledByHRTimer = 1;
-    hrtimer_start(&pdata->key_timer, ktime_set(0,(1000/HRTIMER_FRAME)*1000000), HRTIMER_MODE_REL);
-//	AW9523_LOG("%s: end \n", __func__);
-	
+	AW9523_LOG("Scheduling matrix rescan\n");
+	calledByHRTimer = 1;
+	hrtimer_start(&pdata->key_timer,
+		      ktime_set(0, (1000 / HRTIMER_FRAME) * 1000000),
+		      HRTIMER_MODE_REL);
+//      AW9523_LOG("%s: end \n", __func__);
+
 }
 
 static enum hrtimer_restart aw9523_key_timer_func(struct hrtimer *timer)
@@ -552,7 +570,7 @@ static enum hrtimer_restart aw9523_key_timer_func(struct hrtimer *timer)
 
 	schedule_work(&aw9523_key->eint_work);
 
-	return HRTIMER_NORESTART; 
+	return HRTIMER_NORESTART;
 }
 
 /*********************************************************
@@ -564,33 +582,35 @@ static void aw9523_int_work(struct work_struct *work)
 {
 	AW9523_LOG("DelayedWork\n");
 
-	i2c_write_reg(P0_INT, 0xff);			//disable p0 port irq
-	i2c_read_reg(P0_INPUT);						// clear P0 Input Interrupt
+	i2c_write_reg(P0_INT, 0xff);	//disable p0 port irq
+	i2c_read_reg(P0_INPUT);	// clear P0 Input Interrupt
 
-	hrtimer_start(&aw9523_key->key_timer, ktime_set(0,(1000/(HRTIMER_FRAME*10))*1000000), HRTIMER_MODE_REL);
+	hrtimer_start(&aw9523_key->key_timer,
+		      ktime_set(0, (1000 / (HRTIMER_FRAME * 10)) * 1000000),
+		      HRTIMER_MODE_REL);
 }
 
 static irqreturn_t aw9523_key_eint_func(int irq, void *desc)
-{	
+{
 	disable_irq_nosync(aw9523_key->irq);
 	AW9523_LOG("Interrupt Enter\n");
 	calledByHRTimer = 0;
 
-	if(aw9523_key == NULL){
+	if (aw9523_key == NULL) {
 		printk("aw9523_key == NULL");
-		return  IRQ_NONE;
+		return IRQ_NONE;
 	}
-
-//	schedule_work(&aw9523_key->eint_work);
+//      schedule_work(&aw9523_key->eint_work);
 	schedule_delayed_work(&aw9523_key->work, msecs_to_jiffies(1));
 
 	return IRQ_HANDLED;
 
 }
+
 int aw9523_key_setup_eint(void)
 {
 	int ret = 0;
-	u32 ints[2] = {0, 0};
+	u32 ints[2] = { 0, 0 };
 
 	int_pin = pinctrl_lookup_state(aw9523_pin, "aw9523_int_pin");
 	if (IS_ERR(int_pin)) {
@@ -598,21 +618,29 @@ int aw9523_key_setup_eint(void)
 		pr_debug("%s : pinctrl err, aw9523_int_pin\n", __func__);
 	}
 
-	aw9523_key->irq_node = of_find_compatible_node(NULL, NULL, "mediatek,aw9523-eint");
+	aw9523_key->irq_node =
+	    of_find_compatible_node(NULL, NULL, "mediatek,aw9523-eint");
 
 	if (aw9523_key->irq_node) {
-		of_property_read_u32_array(aw9523_key->irq_node, "debounce", ints, ARRAY_SIZE(ints));
+		of_property_read_u32_array(aw9523_key->irq_node,
+					   "debounce", ints,
+					   ARRAY_SIZE(ints));
 		gpio_set_debounce(ints[0], ints[1]);
 		pinctrl_select_state(aw9523_pin, int_pin);
-		AW9523_LOG("%s ints[0] = %d, ints[1] = %d!!\n", __func__, ints[0], ints[1]);
+		AW9523_LOG("%s ints[0] = %d, ints[1] = %d!!\n",
+			   __func__, ints[0], ints[1]);
 
-		aw9523_key->irq = irq_of_parse_and_map(aw9523_key->irq_node, 0);
+		aw9523_key->irq =
+		    irq_of_parse_and_map(aw9523_key->irq_node, 0);
 		AW9523_LOG("%s irq = %d\n", __func__, aw9523_key->irq);
 		if (!aw9523_key->irq) {
-			printk("%s irq_of_parse_and_map fail!!\n", __func__);
+			printk("%s irq_of_parse_and_map fail!!\n",
+			       __func__);
 			return -EINVAL;
 		}
-		if (request_irq(aw9523_key->irq, aw9523_key_eint_func, IRQ_TYPE_NONE, "aw9523-eint", NULL)) {
+		if (request_irq
+		    (aw9523_key->irq, aw9523_key_eint_func, IRQ_TYPE_NONE,
+		     "aw9523-eint", NULL)) {
 			printk("%s IRQ LINE NOT AVAILABLE!!\n", __func__);
 			return -EINVAL;
 		}
@@ -621,25 +649,25 @@ int aw9523_key_setup_eint(void)
 		return -EINVAL;
 	}
 
-    return 0;
+	return 0;
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // i2c write and read
-//////////////////////////////////////////////////////////////////////////
-////////////////////////////////////
-static unsigned char i2c_write_reg(unsigned char addr, unsigned char reg_data)
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////
+static unsigned char i2c_write_reg(unsigned char addr,
+				   unsigned char reg_data)
 {
 	char ret;
-	u8 wdbuf[512] = {0};
+	u8 wdbuf[512] = { 0 };
 
 	struct i2c_msg msgs[] = {
 		{
-			.addr	= aw9523_i2c_client->addr,
-			.flags	= 0,
-			.len	= 2,
-			.buf	= wdbuf,
-		},
+		 .addr = aw9523_i2c_client->addr,
+		 .flags = 0,
+		 .len = 2,
+		 .buf = wdbuf,
+		 },
 	};
 
 	wdbuf[0] = addr;
@@ -649,36 +677,36 @@ static unsigned char i2c_write_reg(unsigned char addr, unsigned char reg_data)
 	if (ret < 0)
 		pr_err("msg %s i2c read error: %d\n", __func__, ret);
 
-    return ret;
+	return ret;
 }
 
 static unsigned char i2c_read_reg(unsigned char addr)
 {
 	unsigned char ret;
-	u8 rdbuf[512] = {0};
+	u8 rdbuf[512] = { 0 };
 
 	struct i2c_msg msgs[] = {
 		{
-			.addr	= aw9523_i2c_client->addr,
-			.flags	= 0,
-			.len	= 1,
-			.buf	= rdbuf,
-		},
+		 .addr = aw9523_i2c_client->addr,
+		 .flags = 0,
+		 .len = 1,
+		 .buf = rdbuf,
+		 },
 		{
-			.addr	= aw9523_i2c_client->addr,
-			.flags	= I2C_M_RD,
-			.len	= 1,
-			.buf	= rdbuf,
-		},
+		 .addr = aw9523_i2c_client->addr,
+		 .flags = I2C_M_RD,
+		 .len = 1,
+		 .buf = rdbuf,
+		 },
 	};
 
 	rdbuf[0] = addr;
-	
+
 	ret = i2c_transfer(aw9523_i2c_client->adapter, msgs, 2);
 	if (ret < 0)
 		pr_err("msg %s i2c read error: %d\n", __func__, ret);
 
-    return rdbuf[0];
+	return rdbuf[0];
 }
 
 
@@ -687,39 +715,41 @@ static unsigned char i2c_read_reg(unsigned char addr)
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 static void aw9523_init_keycfg(void)
 {
-	i2c_write_reg(SW_RSTN, 0x00);		// Software Reset
+	i2c_write_reg(SW_RSTN, 0x00);	// Software Reset
 
-	i2c_write_reg(P0_CONFIG, 0xFF);		// P0: Input Mode
+	i2c_write_reg(P0_CONFIG, 0xFF);	// P0: Input Mode
 	i2c_write_reg(P1_CONFIG, 0x00);	// P1: Output Mode
 	i2c_write_reg(P1_OUTPUT, 0x00);	// P1: 0000 0000
 
-	i2c_write_reg(P0_INT, 0x00);		// P0: Enable Interrupt
-	i2c_write_reg(P1_INT, 0xFF);			// P1: Disable Interrupt
+	i2c_write_reg(P0_INT, 0x00);	// P0: Enable Interrupt
+	i2c_write_reg(P1_INT, 0xFF);	// P1: Disable Interrupt
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //Debug
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-static ssize_t aw9523_get_reg(struct device* cd,struct device_attribute *attr, char* buf)
+static ssize_t aw9523_get_reg(struct device *cd,
+			      struct device_attribute *attr, char *buf)
 {
 	unsigned char reg_val;
 	ssize_t len = 0;
 	u8 i;
-	for(i=0;i<0x30;i++)
-	{
+	for (i = 0; i < 0x30; i++) {
 		reg_val = i2c_read_reg(i);
-		len += snprintf(buf+len, PAGE_SIZE-len, "reg%2X = 0x%2X, ", i,reg_val);
+		len += snprintf(buf + len, PAGE_SIZE - len,
+				"reg%2X = 0x%2X, ", i, reg_val);
 	}
 
 	return len;
 }
 
-static ssize_t aw9523_set_reg(struct device* cd, struct device_attribute *attr, const char* buf, size_t len)
+static ssize_t aw9523_set_reg(struct device *cd,
+			      struct device_attribute *attr,
+			      const char *buf, size_t len)
 {
 	unsigned int databuf[2];
-	if(2 == sscanf(buf,"%x %x",&databuf[0], &databuf[1]))
-	{
-		i2c_write_reg(databuf[0],databuf[1]);
+	if (2 == sscanf(buf, "%x %x", &databuf[0], &databuf[1])) {
+		i2c_write_reg(databuf[0], databuf[1]);
 	}
 	return len;
 }
@@ -742,11 +772,11 @@ static void aw9523_input_register(void)
 	struct input_dev *input_dev;
 
 	input_dev = input_allocate_device();
-	if (!input_dev){
+	if (!input_dev) {
 		err = -ENOMEM;
 		goto exit_input_dev_alloc_failed;
 	}
-	
+
 	aw9523_key->input_dev = input_dev;
 	__set_bit(EV_KEY, input_dev->evbit);
 	__set_bit(EV_SYN, input_dev->evbit);
@@ -806,52 +836,58 @@ static void aw9523_input_register(void)
 	input_set_capability(aw9523_key->input_dev, EV_KEY, KEY_I);
 	input_set_capability(aw9523_key->input_dev, EV_KEY, KEY_UNKNOWN);
 
-	input_dev->name	= AW9523_I2C_NAME;
+	input_dev->name = AW9523_I2C_NAME;
 	err = input_register_device(input_dev);
 	if (err) {
-//		dev_err(&client->dev,
-//		"aw9523_i2c_probe: failed to register input device: %s\n",
-//		dev_name(&client->dev));
+//              dev_err(&client->dev,
+//              "aw9523_i2c_probe: failed to register input device: %s\n",
+//              dev_name(&client->dev));
 		goto exit_input_register_device_failed;
-	}	
-	
-exit_input_dev_alloc_failed:
+	}
+
+      exit_input_dev_alloc_failed:
 	cancel_work_sync(&aw9523_key->eint_work);
-exit_input_register_device_failed:
+      exit_input_register_device_failed:
 	input_free_device(input_dev);
 }
 
 #ifdef CONFIG_AW9523_FB
 static int aw9523_fb_notifier_callback(struct notifier_block *self,
-                     unsigned long event, void *data)
+				       unsigned long event, void *data)
 {
-	struct aw9523_key_data *aw9523 = container_of(self, struct aw9523_key_data, fb_notif);
-    struct fb_event *evdata = data;
-    int *blank;
+	struct aw9523_key_data *aw9523 =
+	    container_of(self, struct aw9523_key_data, fb_notif);
+	struct fb_event *evdata = data;
+	int *blank;
 
-    if (evdata && evdata->data && event == FB_EVENT_BLANK) {
-        blank = evdata->data;
-        if (*blank == FB_BLANK_UNBLANK) {
-            AW9523_LOG("%s: fbnotify screen on mode.\n", __func__);
+	if (evdata && evdata->data && event == FB_EVENT_BLANK) {
+		blank = evdata->data;
+		if (*blank == FB_BLANK_UNBLANK) {
+			AW9523_LOG("%s: fbnotify screen on mode.\n",
+				   __func__);
 			aw9523_i2c_early_resume(aw9523_i2c_client);
 			aw9523->is_screen_on = true;
-        } else if (*blank == FB_BLANK_POWERDOWN) {
-			AW9523_LOG("%s: fbnotify screen off mode.\n", __func__);
+		} else if (*blank == FB_BLANK_POWERDOWN) {
+			AW9523_LOG("%s: fbnotify screen off mode.\n",
+				   __func__);
 			//这两句代码顺序不能反了，不然会出现进入休眠的同时按按键就出现乱报点，导致按键无效问题。
 			//先执行赋值，代码会先执行上面的all key release那段代码再执行进入suspend。
-			aw9523->is_screen_on = false; 
+			// Google translate:
+			// The order of the two codes can not be reversed, otherwise there will be random reporting points when pressing the button while entering the hibernation, resulting in invalid buttons.
+			// First perform the assignment, the code will first execute the above all key release code and then execute into suspend.
+			aw9523->is_screen_on = false;
 			aw9523_i2c_early_suspend(aw9523_i2c_client);
-			
-			
-        }
-    }
-	
-	AW9523_LOG("%s: aw9523_key->is_screen_on=%d \n", __func__,aw9523_key->is_screen_on);	
-    return 0;
+		}
+	}
+
+	AW9523_LOG("%s: aw9523_key->is_screen_on=%d \n", __func__,
+		   aw9523_key->is_screen_on);
+	return 0;
 }
 #endif
 
-static int aw9523_i2c_probe(struct i2c_client *client, const struct i2c_device_id *id)
+static int aw9523_i2c_probe(struct i2c_client *client,
+			    const struct i2c_device_id *id)
 {
 	unsigned char reg_value = 0;
 	int err = 0;
@@ -864,60 +900,61 @@ static int aw9523_i2c_probe(struct i2c_client *client, const struct i2c_device_i
 	}
 	AW9523_LOG("%s: kzalloc\n", __func__);
 	aw9523_key = kzalloc(sizeof(*aw9523_key), GFP_KERNEL);
-	if (!aw9523_key)	{
+	if (!aw9523_key) {
 		err = -ENOMEM;
 		goto exit_alloc_data_failed;
 	}
 
 	aw9523_i2c_client = client;
 	i2c_set_clientdata(client, aw9523_key);
-	
+
 	aw9523_hw_reset();
 
 	// CHIP ID
-	while((cnt>0)&&(reg_value != 0x23)){
+	while ((cnt > 0) && (reg_value != 0x23)) {
 		reg_value = i2c_read_reg(0x10);
 		printk("aw9523 chipid=0x%2x\n", reg_value);
-    		cnt --;
-	    	msleep(10);
-		
+		cnt--;
+		msleep(10);
 	}
-	if(!cnt){
+	if (!cnt) {
 		err = -ENODEV;
 		goto exit_create_singlethread;
 	}
-	
+
 	INIT_DELAYED_WORK(&aw9523_key->work, aw9523_int_work);
-	
-	aw9523_key->delay = 10;//50
+
+	aw9523_key->delay = 10;	//50
 	aw9523_key->dev = &client->dev;
 	aw9523_key->is_screen_on = 1;
 
 	aw9523_input_register();
-	
-	aw9523_key->keymap_len = sizeof(key_map)/sizeof(KEY_STATE);
-	aw9523_key->keymap = (KEY_STATE *)&key_map;
-	
+
+	aw9523_key->keymap_len = sizeof(key_map) / sizeof(KEY_STATE);
+	aw9523_key->keymap = (KEY_STATE *) & key_map;
+
 	aw9523_init_keycfg();
-	
+
 #ifdef CONFIG_AW9523_FB
 	aw9523_key->fb_notif.notifier_call = aw9523_fb_notifier_callback;
-    err = fb_register_client(&aw9523_key->fb_notif);
-    if (err) {
-		pr_err("%s: Unable to register aw9523_key fb_notifier: %d\n", __func__, err);
+	err = fb_register_client(&aw9523_key->fb_notif);
+	if (err) {
+		pr_err("%s: Unable to register aw9523_key fb_notifier: %d\n",
+		       __func__, err);
+	} else {
+		pr_info("%s: Success to register aw9523_key fb_notifier.\n",
+			__func__);
 	}
-	else {
-		pr_info("%s: Success to register aw9523_key fb_notifier.\n", __func__);
-	}
-#endif	
+#endif
 	//Interrupt
 	aw9523_key_setup_eint();
 	INIT_WORK(&aw9523_key->eint_work, aw9523_key_eint_work);
-	hrtimer_init(&aw9523_key->key_timer, CLOCK_MONOTONIC, HRTIMER_MODE_REL);
+	hrtimer_init(&aw9523_key->key_timer, CLOCK_MONOTONIC,
+		     HRTIMER_MODE_REL);
 	aw9523_key->key_timer.function = aw9523_key_timer_func;
 
 	aw9523_create_sysfs(client);
-	
+
 	memset(keyst_new, P0_KROW_MASK, sizeof(keyst_new));
 	memset(keyst_old, P0_KROW_MASK, sizeof(keyst_old));
 	memset(keyst_def, P0_KROW_MASK, sizeof(keyst_def));
@@ -929,8 +966,9 @@ exit_create_singlethread:
 exit_alloc_data_failed:
 	kfree(aw9523_key);
 exit_check_functionality_failed:
-	return err;	
+	return err;
 }
+
 #define AW9523_I2C_SUSPEND
 
 #ifdef AW9523_EARLAY_SUSPEND
@@ -947,13 +985,14 @@ static void aw9523_i2c_early_suspend(struct i2c_client *client)
 	printk("%s enter222!\n", __func__);
 	//cancel_work_sync(&aw9523_key->eint_work);
 
-	return ;
+	return;
 }
+
 /*----------------------------------------------------------------------------*/
 static void aw9523_i2c_early_resume(struct i2c_client *client)
 {
 	struct aw9523_key_data *aw9523_key = i2c_get_clientdata(client);
-	
+
 	AW9523_LOG("%s enter\n", __func__);
 	enable_irq(aw9523_key->irq);
 
@@ -962,8 +1001,10 @@ static void aw9523_i2c_early_resume(struct i2c_client *client)
 	//INIT_DELAYED_WORK(&aw9523_key->work, aw9523_int_work);
 	//INIT_WORK(&aw9523_key->eint_work, aw9523_key_eint_work);
 	AW9523_LOG("Scheduling matrix rescan2\n");
-	hrtimer_start(&aw9523_key->key_timer, ktime_set(0,(1000/HRTIMER_FRAME)*1000000), HRTIMER_MODE_REL);
-	return ;
+	hrtimer_start(&aw9523_key->key_timer,
+		      ktime_set(0, (1000 / HRTIMER_FRAME) * 1000000),
+		      HRTIMER_MODE_REL);
+	return;
 }
 #endif
 
@@ -975,8 +1016,8 @@ static int aw9523_i2c_suspend(struct i2c_client *client, pm_message_t msg)
 
 	disable_irq_nosync(aw9523_key->irq);
 	//aw9523_key->is_screen_on = false;
-	
-	if (msg.event == PM_EVENT_SUSPEND){
+
+	if (msg.event == PM_EVENT_SUSPEND) {
 		pinctrl_select_state(aw9523_pin, shdn_low);
 		msleep(5);
 		printk("%s enter111!\n", __func__);
@@ -987,12 +1028,13 @@ static int aw9523_i2c_suspend(struct i2c_client *client, pm_message_t msg)
 #endif
 	return 0;
 }
+
 /*----------------------------------------------------------------------------*/
 static int aw9523_i2c_resume(struct i2c_client *client)
 {
 #ifndef AW9523_EARLAY_SUSPEND
 	struct aw9523_key_data *aw9523_key = i2c_get_clientdata(client);
-	
+
 	printk("%s enter\n", __func__);
 	enable_irq(aw9523_key->irq);
 	//aw9523_key->is_screen_on = true;
@@ -1010,25 +1052,25 @@ static int aw9523_i2c_remove(struct i2c_client *client)
 	struct aw9523_key_data *aw9523_key = i2c_get_clientdata(client);
 
 	AW9523_LOG("%s enter\n", __func__);
-	
+
 	cancel_delayed_work_sync(&aw9523_key->work);
 	cancel_work_sync(&aw9523_key->eint_work);
 	input_unregister_device(aw9523_key->input_dev);
-	
+
 	kfree(aw9523_key);
-	
+
 	aw9523_i2c_client = NULL;
 	i2c_set_clientdata(client, NULL);
 #ifdef CONFIG_AW9523_FB
-		fb_unregister_client(&aw9523_key->fb_notif);
+	fb_unregister_client(&aw9523_key->fb_notif);
 #endif
 
 	return 0;
 }
 
 static const struct i2c_device_id aw9523_i2c_id[] = {
-	{ AW9523_I2C_NAME, 0 },
-	{ }
+	{AW9523_I2C_NAME, 0},
+	{}
 };
 
 #ifdef CONFIG_OF
@@ -1039,21 +1081,21 @@ static const struct of_device_id extgpio_of_match[] = {
 #endif
 
 static struct i2c_driver aw9523_i2c_driver = {
-        .driver = {
-                .name   = AW9523_I2C_NAME,
-				.owner = THIS_MODULE,
+	.driver = {
+		   .name = AW9523_I2C_NAME,
+		   .owner = THIS_MODULE,
 #ifdef CONFIG_OF
-				.of_match_table = extgpio_of_match,
+		   .of_match_table = extgpio_of_match,
 #endif
-},
+		   },
 
-        .probe          = aw9523_i2c_probe,
-        .remove         = aw9523_i2c_remove,
- #ifdef AW9523_I2C_SUSPEND
- 		.suspend = aw9523_i2c_suspend,
-		.resume = aw9523_i2c_resume,
- #endif
-        .id_table       = aw9523_i2c_id,
+	.probe = aw9523_i2c_probe,
+	.remove = aw9523_i2c_remove,
+#ifdef AW9523_I2C_SUSPEND
+	.suspend = aw9523_i2c_suspend,
+	.resume = aw9523_i2c_resume,
+#endif
+	.id_table = aw9523_i2c_id,
 };
 
 
@@ -1079,7 +1121,7 @@ static int aw9523_key_probe(struct platform_device *pdev)
 	} else {
 		printk("[%s] Success to init aw9523 pinctrl.\n", __func__);
 	}
-	
+
 	ret = i2c_add_driver(&aw9523_i2c_driver);
 	if (ret != 0) {
 		printk("[%s] failed to register aw9523 i2c driver.\n", __func__);
@@ -1094,26 +1136,27 @@ static int aw9523_key_probe(struct platform_device *pdev)
 //#define AW9523_PLATFORM_SUSPEND
 
 #ifdef AW9523_PLATFORM_SUSPEND
-static int aw9523_key_suspend(struct platform_device *pdev, pm_message_t state)
-{	
+static int aw9523_key_suspend(struct platform_device *pdev,
+			      pm_message_t state)
+{
 	AW9523_LOG("%s enter!\n", __func__);
 	disable_irq_nosync(aw9523_key->irq);
-	
+
 	pinctrl_select_state(aw9523_pin, shdn_low);
 	msleep(5);
 	AW9523_LOG("%s enter111!\n", __func__);
 	cancel_delayed_work_sync(&aw9523_key->work);
 	printk("%s enter222!\n", __func__);
 	cancel_work_sync(&aw9523_key->eint_work);
-	
+
 	return 0;
 }
 
 static int aw9523_key_resume(struct platform_device *pdev)
-{	
+{
 	AW9523_LOG("%s enter!\n", __func__);
 	enable_irq(aw9523_key->irq);
-	
+
 	aw9523_hw_reset();
 	aw9523_init_keycfg();
 	INIT_DELAYED_WORK(&aw9523_key->work, aw9523_int_work);
@@ -1131,33 +1174,36 @@ static const struct of_device_id aw9523plt_of_match[] = {
 #endif
 
 static struct platform_driver aw9523_key_driver = {
-		.probe	 = aw9523_key_probe,
-		.remove	 = aw9523_key_remove,
-		#ifdef AW9523_PLATFORM_SUSPEND
-		.suspend = aw9523_key_suspend,
-		.resume = aw9523_key_resume,
-		#endif
-        .driver = {
-                .name   = "aw9523_key",
-#ifdef CONFIG_OF
-				.of_match_table = aw9523plt_of_match,
+	.probe = aw9523_key_probe,
+	.remove = aw9523_key_remove,
+#ifdef AW9523_PLATFORM_SUSPEND
+	.suspend = aw9523_key_suspend,
+	.resume = aw9523_key_resume,
 #endif
-        }
+	.driver = {
+		   .name = "aw9523_key",
+#ifdef CONFIG_OF
+		   .of_match_table = aw9523plt_of_match,
+#endif
+		   }
 };
 
-static int __init aw9523_key_init(void) {
+static int __init aw9523_key_init(void)
+{
 	int ret;
 	printk("%s start\n", __func__);
-	
+
 	ret = platform_driver_register(&aw9523_key_driver);
 	if (ret) {
-		printk("****[%s] Unable to register driver (%d)\n", __func__, ret);
+		printk("****[%s] Unable to register driver (%d)\n",
+		       __func__, ret);
 		return ret;
-	}		
+	}
 	return 0;
 }
 
-static void __exit aw9523_key_exit(void) {
+static void __exit aw9523_key_exit(void)
+{
 	printk("%s exit\n", __func__);
 	platform_driver_unregister(&aw9523_key_driver);
 }


### PR DESCRIPTION
The Gemini PDA keyboard has 2-key roll-over.  That means that if 3 or more keys are pressed down in some combinations, four keys will actually be detected.  One example is that if K+J+D are pressed simultaneously, the old driver will produce K+J+S+D.  Since I usually use the Dvorak layout, this meant that often if I typed "the" or "those" Gemini would produce "thoe" or "thoese" because I'm lazy about lifting up keys.  It also meant that Control + L_Shift + M & N can't be differentiated from each other.

Instead of adding extra keys (ie. Ghosting) my changed driver now blocks the extra keys, however the keypress _is_ registered if one of the first two keys is released before the third.  Thus "the" in Dvorak is much easier to type, and Control+L_Shift+M will be recorded as long as the Shift or Control is released before the M.  Unfortunately this is the best we can do without redesigning the keyboard matrix.  I also changed the formatting to match the Linux Kernel.

See youtu.be/L3ByBtM-w9I for a description of why keyboard Ghosting happens.